### PR TITLE
Testing `OrganizeImports.targetDialect = Scala3`

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,2 +1,3 @@
 rules = [OrganizeImports]
 OrganizeImports.removeUnused = false
+OrganizeImports.targetDialect = Scala3

--- a/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
@@ -7,7 +7,7 @@ import dotty.tools.dotc.ast.tpd
 import dotty.tools.dotc.core.Constants.*
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.Decorators.em
-import dotty.tools.dotc.core.Flags.{Label => LabelFlag, _}
+import dotty.tools.dotc.core.Flags.{Label as LabelFlag, *}
 import dotty.tools.dotc.core.Phases.*
 import dotty.tools.dotc.core.StdNames.nme
 import dotty.tools.dotc.core.StdNames.str

--- a/compiler/src/dotty/tools/backend/jvm/BTypesFromSymbols.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BTypesFromSymbols.scala
@@ -5,8 +5,8 @@ package jvm
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.Flags.*
 import dotty.tools.dotc.core.Phases
-import dotty.tools.dotc.core.Phases.Phase
 import dotty.tools.dotc.core.Phases.*
+import dotty.tools.dotc.core.Phases.Phase
 import dotty.tools.dotc.core.StdNames
 import dotty.tools.dotc.core.Symbols.*
 

--- a/compiler/src/dotty/tools/backend/jvm/CodeGen.scala
+++ b/compiler/src/dotty/tools/backend/jvm/CodeGen.scala
@@ -4,8 +4,8 @@ import dotty.tools.dotc.CompilationUnit
 import dotty.tools.dotc.ast.Trees.PackageDef
 import dotty.tools.dotc.ast.Trees.ValDef
 import dotty.tools.dotc.ast.tpd
-import dotty.tools.dotc.core.Phases.Phase
 import dotty.tools.dotc.core.*
+import dotty.tools.dotc.core.Phases.Phase
 import dotty.tools.dotc.core.tasty.TastyUnpickler
 import dotty.tools.dotc.interfaces
 import dotty.tools.dotc.report

--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -1,13 +1,13 @@
 package dotty.tools.backend.jvm
 
 import dotty.tools.dotc.ast.tpd
-import dotty.tools.dotc.core.Flags.*
 import dotty.tools.dotc.core.*
+import dotty.tools.dotc.core.Flags.*
 import dotty.tools.dotc.report
 import dotty.tools.dotc.util.ReadOnlyMap
 import dotty.tools.io.AbstractFile
 
-import java.io.{File => _}
+import java.io.File as _
 import scala.language.unsafeNulls
 import scala.reflect.ClassTag
 

--- a/compiler/src/dotty/tools/backend/jvm/GenBCode.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenBCode.scala
@@ -1,8 +1,8 @@
 package dotty.tools.backend.jvm
 
 import dotty.tools.dotc.CompilationUnit
-import dotty.tools.dotc.core.Phases.Phase
 import dotty.tools.dotc.core.*
+import dotty.tools.dotc.core.Phases.Phase
 import dotty.tools.dotc.interfaces.CompilerCallback
 import dotty.tools.dotc.report
 import dotty.tools.io.*

--- a/compiler/src/dotty/tools/backend/jvm/GeneratedClassHandler.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GeneratedClassHandler.scala
@@ -7,8 +7,8 @@ import dotty.tools.dotc.profile.ThreadPoolFactory
 import dotty.tools.io.AbstractFile
 
 import java.nio.channels.ClosedByInterruptException
-import java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy
 import java.util.concurrent.*
+import java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy
 import scala.collection.mutable.ListBuffer
 import scala.compiletime.uninitialized
 import scala.concurrent.Await

--- a/compiler/src/dotty/tools/backend/jvm/PostProcessorFrontendAccess.scala
+++ b/compiler/src/dotty/tools/backend/jvm/PostProcessorFrontendAccess.scala
@@ -7,8 +7,8 @@ import dotty.tools.dotc.reporting.Message
 import dotty.tools.dotc.util.*
 import dotty.tools.io.AbstractFile
 
-import java.util.{Collection => JCollection}
-import java.util.{Map => JMap}
+import java.util.Collection as JCollection
+import java.util.Map as JMap
 import scala.collection.mutable.Clearable
 import scala.collection.mutable.HashSet
 import scala.compiletime.uninitialized

--- a/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
@@ -11,16 +11,16 @@ import dotty.tools.dotc.transform.sjs.JSSymUtils.*
 import dotty.tools.dotc.util.SourcePosition
 import org.scalajs.ir
 import org.scalajs.ir.ClassKind
+import org.scalajs.ir.Names as jsNames
 import org.scalajs.ir.Names.ClassName
 import org.scalajs.ir.Names.MethodName
 import org.scalajs.ir.Names.SimpleMethodName
 import org.scalajs.ir.OriginalName
 import org.scalajs.ir.OriginalName.NoOriginalName
 import org.scalajs.ir.Position
+import org.scalajs.ir.Trees as js
 import org.scalajs.ir.Trees.OptimizerHints
-import org.scalajs.ir.{Names => jsNames}
-import org.scalajs.ir.{Trees => js}
-import org.scalajs.ir.{Types => jstpe}
+import org.scalajs.ir.Types as jstpe
 
 import scala.annotation.switch
 import scala.collection.mutable

--- a/compiler/src/dotty/tools/backend/sjs/JSEncoding.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSEncoding.scala
@@ -12,9 +12,9 @@ import org.scalajs.ir.Names.MethodName
 import org.scalajs.ir.Names.SimpleMethodName
 import org.scalajs.ir.OriginalName
 import org.scalajs.ir.OriginalName.NoOriginalName
+import org.scalajs.ir.Trees as js
+import org.scalajs.ir.Types as jstpe
 import org.scalajs.ir.UTF8String
-import org.scalajs.ir.{Trees => js}
-import org.scalajs.ir.{Types => jstpe}
 
 import scala.collection.mutable
 import scala.language.unsafeNulls

--- a/compiler/src/dotty/tools/backend/sjs/JSExportsGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSExportsGen.scala
@@ -6,14 +6,14 @@ import dotty.tools.dotc.transform.sjs.JSExportUtils.*
 import dotty.tools.dotc.transform.sjs.JSSymUtils.*
 import dotty.tools.dotc.util.SourcePosition
 import dotty.tools.dotc.util.SrcPos
+import org.scalajs.ir.Names as jsNames
 import org.scalajs.ir.Names.DefaultModuleID
 import org.scalajs.ir.OriginalName.NoOriginalName
 import org.scalajs.ir.Position
 import org.scalajs.ir.Position.NoPosition
+import org.scalajs.ir.Trees as js
 import org.scalajs.ir.Trees.OptimizerHints
-import org.scalajs.ir.{Names => jsNames}
-import org.scalajs.ir.{Trees => js}
-import org.scalajs.ir.{Types => jstpe}
+import org.scalajs.ir.Types as jstpe
 
 import scala.annotation.tailrec
 import scala.collection.mutable

--- a/compiler/src/dotty/tools/dotc/classpath/DirectoryClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/DirectoryClassPath.scala
@@ -12,7 +12,7 @@ import dotty.tools.io.EfficientClassPath
 import dotty.tools.io.JDK9Reflectors
 import dotty.tools.io.PlainFile
 
-import java.io.{File => JFile}
+import java.io.File as JFile
 import java.net.URI
 import java.net.URL
 import java.nio.file.FileSystems

--- a/compiler/src/dotty/tools/dotc/classpath/FileUtils.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/FileUtils.scala
@@ -6,8 +6,8 @@ package dotc.classpath
 
 import dotty.tools.io.AbstractFile
 
+import java.io.File as JFile
 import java.io.FileFilter
-import java.io.{File => JFile}
 import java.net.URL
 import scala.language.unsafeNulls
 

--- a/compiler/src/dotty/tools/dotc/config/Properties.scala
+++ b/compiler/src/dotty/tools/dotc/config/Properties.scala
@@ -4,7 +4,7 @@ package config
 
 import java.io.IOException
 import java.nio.charset.StandardCharsets
-import java.util.jar.Attributes.{ Name => AttributeName }
+import java.util.jar.Attributes.Name as AttributeName
 import scala.annotation.internal.sharable
 import scala.language.unsafeNulls
 

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -3,7 +3,7 @@ package dotc
 package core
 
 import scala.annotation.tailrec
-import scala.annotation.{threadUnsafe => tu}
+import scala.annotation.threadUnsafe as tu
 import scala.collection.mutable
 import scala.compiletime.uninitialized
 

--- a/compiler/src/dotty/tools/dotc/core/Hashable.scala
+++ b/compiler/src/dotty/tools/dotc/core/Hashable.scala
@@ -1,7 +1,7 @@
 package dotty.tools.dotc
 package core
 
-import scala.util.hashing.{ MurmurHash3 => hashing }
+import scala.util.hashing.MurmurHash3 as hashing
 
 import Types.*
 import annotation.tailrec

--- a/compiler/src/dotty/tools/dotc/core/Phases.scala
+++ b/compiler/src/dotty/tools/dotc/core/Phases.scala
@@ -3,8 +3,8 @@ package dotc
 package core
 
 import dotty.tools.backend.jvm.GenBCode
-import dotty.tools.dotc.transform.MegaPhase.*
 import dotty.tools.dotc.transform.*
+import dotty.tools.dotc.transform.MegaPhase.*
 
 import scala.annotation.internal.sharable
 import scala.collection.mutable.ListBuffer

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -5,7 +5,7 @@ package core
 import java.lang.ref.WeakReference
 import scala.annotation.internal.sharable
 import scala.annotation.threadUnsafe
-import scala.util.hashing.{ MurmurHash3 => hashing }
+import scala.util.hashing.MurmurHash3 as hashing
 
 import Symbols.*
 import Flags.*

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -4,8 +4,8 @@ package core
 package tasty
 
 import dotty.tools.tasty.TastyBuffer.*
-import dotty.tools.tasty.TastyFormat.ASTsSection
 import dotty.tools.tasty.TastyFormat.*
+import dotty.tools.tasty.TastyFormat.ASTsSection
 
 import scala.language.unsafeNulls
 

--- a/compiler/src/dotty/tools/dotc/decompiler/IDEDecompilerDriver.scala
+++ b/compiler/src/dotty/tools/dotc/decompiler/IDEDecompilerDriver.scala
@@ -2,8 +2,8 @@ package dotty.tools
 package dotc
 package decompiler
 
-import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.*
+import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.tasty.TastyHTMLPrinter
 import dotty.tools.dotc.reporting.*
 import dotty.tools.io.AbstractFile

--- a/compiler/src/dotty/tools/dotc/fromtasty/Debug.scala
+++ b/compiler/src/dotty/tools/dotc/fromtasty/Debug.scala
@@ -4,7 +4,7 @@ package fromtasty
 
 import dotty.tools.io.Directory
 
-import java.io.{File => JFile}
+import java.io.File as JFile
 import java.nio.file.Files
 import java.nio.file.Paths
 import scala.language.unsafeNulls

--- a/compiler/src/dotty/tools/dotc/plugins/Plugins.scala
+++ b/compiler/src/dotty/tools/dotc/plugins/Plugins.scala
@@ -11,7 +11,7 @@ import Contexts.*
 import Decorators.em
 import config.{ PathResolver, Feature }
 import Phases.*
-import config.Printers.plugins.{ println => debug }
+import config.Printers.plugins.println as debug
 import config.Properties
 
 /** Support for run-time loading of compiler plugins.

--- a/compiler/src/dotty/tools/dotc/printing/Printer.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Printer.scala
@@ -12,7 +12,7 @@ import Symbols.Symbol
 import Scopes.Scope
 import Constants.Constant
 import Names.Name
-import Denotations._
+import Denotations.*
 import Annotations.Annotation
 import Contexts.Context
 import typer.Implicits.*

--- a/compiler/src/dotty/tools/dotc/profile/ThreadPoolFactory.scala
+++ b/compiler/src/dotty/tools/dotc/profile/ThreadPoolFactory.scala
@@ -3,8 +3,8 @@ package dotty.tools.dotc.profile
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.Phases.Phase
 
-import java.util.concurrent.ThreadPoolExecutor.AbortPolicy
 import java.util.concurrent.*
+import java.util.concurrent.ThreadPoolExecutor.AbortPolicy
 import java.util.concurrent.atomic.AtomicInteger
 import scala.language.unsafeNulls
 

--- a/compiler/src/dotty/tools/dotc/quoted/Interpreter.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/Interpreter.scala
@@ -25,7 +25,7 @@ import dotty.tools.repl.AbstractFileClassLoader
 import java.io.PrintWriter
 import java.io.StringWriter
 import java.lang.reflect.InvocationTargetException
-import java.lang.reflect.{Method => JLRMethod}
+import java.lang.reflect.Method as JLRMethod
 import scala.collection.mutable
 import scala.language.unsafeNulls
 import scala.reflect.ClassTag

--- a/compiler/src/dotty/tools/dotc/quoted/QuotePatterns.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/QuotePatterns.scala
@@ -5,6 +5,7 @@ import dotty.tools.dotc.ast.TreeTypeMap
 import dotty.tools.dotc.ast.Trees.*
 import dotty.tools.dotc.ast.tpd
 import dotty.tools.dotc.ast.untpd
+import dotty.tools.dotc.core.*
 import dotty.tools.dotc.core.Annotations.*
 import dotty.tools.dotc.core.Constants.*
 import dotty.tools.dotc.core.Contexts.*
@@ -16,7 +17,6 @@ import dotty.tools.dotc.core.StdNames.*
 import dotty.tools.dotc.core.Symbols.*
 import dotty.tools.dotc.core.TypeOps.*
 import dotty.tools.dotc.core.Types.*
-import dotty.tools.dotc.core.*
 import dotty.tools.dotc.reporting.IllegalVariableInPatternAlternative
 
 import scala.collection.mutable

--- a/compiler/src/dotty/tools/dotc/reporting/Diagnostic.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Diagnostic.scala
@@ -10,8 +10,8 @@ import dotty.tools.dotc.interfaces.Diagnostic.WARNING
 import dotty.tools.dotc.util.SourcePosition
 
 import java.util.Collections
+import java.util.List as JList
 import java.util.Optional
-import java.util.{List => JList}
 import scala.language.unsafeNulls
 import scala.util.chaining.*
 

--- a/compiler/src/dotty/tools/dotc/reporting/MessageRendering.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/MessageRendering.scala
@@ -2,7 +2,7 @@ package dotty.tools
 package dotc
 package reporting
 
-import java.lang.System.{lineSeparator => EOL}
+import java.lang.System.lineSeparator as EOL
 import scala.annotation.switch
 import scala.collection.mutable
 import scala.language.unsafeNulls

--- a/compiler/src/dotty/tools/dotc/semanticdb/ConstantOps.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/ConstantOps.scala
@@ -2,7 +2,7 @@ package dotty.tools
 package dotc
 package semanticdb
 
-import dotty.tools.dotc.{semanticdb => s}
+import dotty.tools.dotc.semanticdb as s
 
 import core.Contexts.Context
 import core.Constants.*

--- a/compiler/src/dotty/tools/dotc/semanticdb/Descriptor.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/Descriptor.scala
@@ -1,8 +1,8 @@
 package dotty.tools.dotc.semanticdb
 
-import dotty.tools.dotc.semanticdb.{Descriptor => d}
+import dotty.tools.dotc.semanticdb.Descriptor as d
 
-import java.lang.System.{lineSeparator => EOL}
+import java.lang.System.lineSeparator as EOL
 import scala.language.unsafeNulls
 
 class DescriptorParser(s: String) {

--- a/compiler/src/dotty/tools/dotc/semanticdb/DiagnosticOps.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/DiagnosticOps.scala
@@ -5,7 +5,7 @@ import dotty.tools.dotc.interfaces.Diagnostic.ERROR
 import dotty.tools.dotc.interfaces.Diagnostic.INFO
 import dotty.tools.dotc.interfaces.Diagnostic.WARNING
 import dotty.tools.dotc.reporting.Diagnostic
-import dotty.tools.dotc.{semanticdb => s}
+import dotty.tools.dotc.semanticdb as s
 
 import scala.annotation.internal.sharable
 

--- a/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
@@ -3,15 +3,15 @@ package dotc
 package semanticdb
 
 import dotty.tools.dotc.reporting.Diagnostic.Warning
+import dotty.tools.dotc.semanticdb as s
 import dotty.tools.dotc.semanticdb.DiagnosticOps.*
-import dotty.tools.dotc.{semanticdb => s}
 import dotty.tools.io.AbstractFile
 import dotty.tools.io.JarArchive
 
 import java.nio.file.Path
 import scala.PartialFunction.condOpt
 import scala.annotation.tailrec
-import scala.annotation.{threadUnsafe => tu}
+import scala.annotation.threadUnsafe as tu
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
 import scala.language.unsafeNulls

--- a/compiler/src/dotty/tools/dotc/semanticdb/PPrint.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/PPrint.scala
@@ -1,8 +1,8 @@
 package dotty.tools.dotc.semanticdb
 
+import dotty.tools.dotc.semanticdb as s
 import dotty.tools.dotc.semanticdb.Scala3.given
 import dotty.tools.dotc.util.SourceFile
-import dotty.tools.dotc.{semanticdb => s}
 
 import scala.collection.mutable
 

--- a/compiler/src/dotty/tools/dotc/semanticdb/Scala3.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/Scala3.scala
@@ -18,7 +18,7 @@ import core.Types.{Type, TypeBounds}
 import core.Flags.*
 import core.NameKinds
 import core.StdNames.nme
-import SymbolInformation.{Kind => k}
+import SymbolInformation.Kind as k
 
 object Scala3:
   import Symbols.*

--- a/compiler/src/dotty/tools/dotc/semanticdb/SyntheticsExtractor.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/SyntheticsExtractor.scala
@@ -5,7 +5,7 @@ import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.Flags.*
 import dotty.tools.dotc.core.NameKinds
 import dotty.tools.dotc.core.StdNames.nme
-import dotty.tools.dotc.{semanticdb => s}
+import dotty.tools.dotc.semanticdb as s
 
 
 class SyntheticsExtractor:

--- a/compiler/src/dotty/tools/dotc/semanticdb/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/TypeOps.scala
@@ -3,7 +3,7 @@ package dotc
 package semanticdb
 
 import dotty.tools.dotc.core.Names.Designator
-import dotty.tools.dotc.{semanticdb => s}
+import dotty.tools.dotc.semanticdb as s
 
 import scala.util.chaining.scalaUtilChainingOps
 

--- a/compiler/src/dotty/tools/dotc/transform/CheckShadowing.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckShadowing.scala
@@ -9,8 +9,8 @@ import dotty.tools.dotc.ast.untpd.ImportSelector
 import dotty.tools.dotc.cc.boxedCaptureSet
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.Denotations.SingleDenotation
-import dotty.tools.dotc.core.Flags.EmptyFlags
 import dotty.tools.dotc.core.Flags.*
+import dotty.tools.dotc.core.Flags.EmptyFlags
 import dotty.tools.dotc.core.Mode.Type
 import dotty.tools.dotc.core.Names.Name
 import dotty.tools.dotc.core.Names.SimpleName

--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -20,8 +20,8 @@ import dotty.tools.dotc.core.Names.Name
 import dotty.tools.dotc.core.Phases.Phase
 import dotty.tools.dotc.core.StdNames
 import dotty.tools.dotc.core.StdNames.nme
-import dotty.tools.dotc.core.Symbols.Symbol
 import dotty.tools.dotc.core.Symbols.*
+import dotty.tools.dotc.core.Symbols.Symbol
 import dotty.tools.dotc.core.Types.AnnotatedType
 import dotty.tools.dotc.core.Types.ConstantType
 import dotty.tools.dotc.core.Types.NoType

--- a/compiler/src/dotty/tools/dotc/transform/MacroAnnotations.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MacroAnnotations.scala
@@ -3,7 +3,7 @@ package transform
 
 import dotty.tools.dotc.ast.Trees.*
 import dotty.tools.dotc.ast.tpd
-import dotty.tools.dotc.config.Printers.{macroAnnot => debug}
+import dotty.tools.dotc.config.Printers.macroAnnot as debug
 import dotty.tools.dotc.core.Annotations.*
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.Decorators.*

--- a/compiler/src/dotty/tools/dotc/transform/SelectStatic.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SelectStatic.scala
@@ -2,11 +2,11 @@ package dotty.tools.dotc
 package transform
 
 import dotty.tools.dotc.ast.tpd
+import dotty.tools.dotc.core.*
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.DenotTransformers.IdentityDenotTransformer
 import dotty.tools.dotc.core.Flags.*
 import dotty.tools.dotc.core.Symbols.*
-import dotty.tools.dotc.core.*
 import dotty.tools.dotc.transform.MegaPhase.*
 
 

--- a/compiler/src/dotty/tools/dotc/transform/Splicer.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splicer.scala
@@ -23,7 +23,7 @@ import dotty.tools.repl.AbstractFileClassLoader
 import java.io.PrintWriter
 import java.io.StringWriter
 import java.lang.reflect.InvocationTargetException
-import java.lang.reflect.{Method => JLRMethod}
+import java.lang.reflect.Method as JLRMethod
 import scala.language.unsafeNulls
 import scala.quoted.Quotes
 import scala.quoted.runtime.impl.*

--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -19,7 +19,7 @@ import TypeErasure.*
 import core.Flags.*
 import util.Spans.*
 import reporting.*
-import config.Printers.{ transforms => debug }
+import config.Printers.transforms as debug
 import patmat.Typ
 
 /** This transform normalizes type tests and type casts,

--- a/compiler/src/dotty/tools/dotc/transform/UncacheGivenAliases.scala
+++ b/compiler/src/dotty/tools/dotc/transform/UncacheGivenAliases.scala
@@ -2,7 +2,7 @@ package dotty.tools.dotc
 package transform
 
 import MegaPhase.*
-import core.DenotTransformers.{IdentityDenotTransformer}
+import core.DenotTransformers.IdentityDenotTransformer
 import core.Symbols.*
 import core.Contexts.*
 import core.Types.*

--- a/compiler/src/dotty/tools/dotc/transform/localopt/FormatChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/localopt/FormatChecker.scala
@@ -1,7 +1,7 @@
 package dotty.tools.dotc
 package transform.localopt
 
-import dotty.tools.dotc.ast.tpd.{Match => _, *}
+import dotty.tools.dotc.ast.tpd.{Match as _, *}
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.Phases.typerPhase
 import dotty.tools.dotc.core.Symbols.*

--- a/compiler/src/dotty/tools/dotc/transform/sjs/JSSymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/sjs/JSSymUtils.scala
@@ -3,7 +3,7 @@ package transform
 package sjs
 
 import dotty.tools.backend.sjs.JSDefinitions.jsdefn
-import org.scalajs.ir.{Trees => js}
+import org.scalajs.ir.Trees as js
 
 import core.*
 import Constants.*

--- a/compiler/src/dotty/tools/dotc/typer/Docstrings.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Docstrings.scala
@@ -6,7 +6,7 @@ import core.*
 import Contexts.*
 import Symbols.*
 import Decorators.*
-import Comments.{_, given}
+import Comments.{*, given}
 import ast.tpd
 
 object Docstrings {

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -14,7 +14,7 @@ import ProtoTypes.*
 import NameKinds.UniqueName
 import util.Spans.*
 import util.{Stats, SimpleIdentityMap, SimpleIdentitySet, SrcPos}
-import Decorators._
+import Decorators.*
 import config.Printers.{gadts, typr}
 import annotation.tailrec
 import reporting.*

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -20,7 +20,7 @@ import Names.*
 import NameOps.*
 import Flags.*
 import Decorators.*
-import Comments.{_, given}
+import Comments.{*, given}
 import NameKinds.DefaultGetterName
 import ast.desugar
 import ast.desugar.*

--- a/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
+++ b/compiler/src/dotty/tools/dotc/typer/QuotesAndSplices.scala
@@ -4,6 +4,7 @@ package typer
 import dotty.tools.dotc.ast.*
 import dotty.tools.dotc.config.Feature.*
 import dotty.tools.dotc.config.SourceVersion.*
+import dotty.tools.dotc.core.*
 import dotty.tools.dotc.core.Annotations.*
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.Decorators.*
@@ -13,7 +14,6 @@ import dotty.tools.dotc.core.Names.*
 import dotty.tools.dotc.core.StdNames.*
 import dotty.tools.dotc.core.Symbols.*
 import dotty.tools.dotc.core.Types.*
-import dotty.tools.dotc.core.*
 import dotty.tools.dotc.inlines.PrepareInlineable
 import dotty.tools.dotc.quoted.QuotePatterns
 import dotty.tools.dotc.reporting.IllegalVariableInPatternAlternative

--- a/compiler/src/dotty/tools/dotc/typer/TyperPhase.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TyperPhase.scala
@@ -11,7 +11,7 @@ import Phases.*
 import Contexts.*
 import Symbols.*
 import ImportInfo.withRootImports
-import parsing.{Parser => ParserPhase}
+import parsing.Parser as ParserPhase
 import config.Printers.typr
 import inlines.PrepareInlineable
 import util.Stats.*

--- a/compiler/src/dotty/tools/io/File.scala
+++ b/compiler/src/dotty/tools/io/File.scala
@@ -8,7 +8,7 @@
 
 package dotty.tools.io
 
-import java.io.{File => JavaIoFile, _}
+import java.io.{File as JavaIoFile, *}
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.nio.file.StandardOpenOption.*

--- a/compiler/src/dotty/tools/io/Streamable.scala
+++ b/compiler/src/dotty/tools/io/Streamable.scala
@@ -7,9 +7,9 @@ package dotty.tools.io
 
 import java.io.BufferedInputStream
 import java.io.BufferedReader
+import java.io.Closeable as JCloseable
 import java.io.InputStream
 import java.io.InputStreamReader
-import java.io.{Closeable => JCloseable}
 import java.net.URL
 import scala.collection.mutable.ArrayBuffer
 import scala.io.BufferedSource

--- a/compiler/src/dotty/tools/repl/JLineTerminal.scala
+++ b/compiler/src/dotty/tools/repl/JLineTerminal.scala
@@ -7,8 +7,8 @@ import dotty.tools.dotc.printing.SyntaxHighlighting
 import dotty.tools.dotc.reporting.Reporter
 import dotty.tools.dotc.util.SourceFile
 import org.jline.reader
-import org.jline.reader.Parser.ParseContext
 import org.jline.reader.*
+import org.jline.reader.Parser.ParseContext
 import org.jline.reader.impl.LineReaderImpl
 import org.jline.reader.impl.history.DefaultHistory
 import org.jline.terminal.TerminalBuilder

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -37,8 +37,8 @@ import dotty.tools.io.*
 import dotty.tools.runner.ScalaClassLoader.*
 import org.jline.reader.*
 
+import java.io.File as JFile
 import java.io.PrintStream
-import java.io.{File => JFile}
 import java.nio.charset.StandardCharsets
 import scala.annotation.tailrec
 import scala.collection.mutable

--- a/compiler/src/dotty/tools/repl/ScriptEngine.scala
+++ b/compiler/src/dotty/tools/repl/ScriptEngine.scala
@@ -6,10 +6,10 @@ import java.io.StringWriter
 import javax.script.AbstractScriptEngine
 import javax.script.Bindings
 import javax.script.ScriptContext
+import javax.script.ScriptEngine as JScriptEngine
 import javax.script.ScriptEngineFactory
 import javax.script.ScriptException
 import javax.script.SimpleBindings
-import javax.script.{ScriptEngine => JScriptEngine}
 import scala.language.unsafeNulls
 
 import dotc.core.StdNames.str

--- a/compiler/src/dotty/tools/scripting/Util.scala
+++ b/compiler/src/dotty/tools/scripting/Util.scala
@@ -3,8 +3,8 @@ package dotty.tools.scripting
 import java.io.File
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
-import java.net.{ URLClassLoader }
-import java.nio.file.{ Path }
+import java.net.URLClassLoader
+import java.nio.file.Path
 import scala.language.unsafeNulls
 
 object Util:

--- a/compiler/test/dotc/comptest.scala
+++ b/compiler/test/dotc/comptest.scala
@@ -4,7 +4,7 @@ import dotty.tools.vulpix.ParallelTesting
 import dotty.tools.vulpix.TestFlags
 import dotty.tools.vulpix.TestGroup
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 object comptest extends ParallelTesting {
 

--- a/compiler/test/dotty/Properties.scala
+++ b/compiler/test/dotty/Properties.scala
@@ -1,6 +1,6 @@
 package dotty
 
-import java.nio.file._
+import java.nio.file.*
 import scala.language.unsafeNulls
 
 /** Runtime properties from defines or environmnent */

--- a/compiler/test/dotty/tools/AnnotationsTests.scala
+++ b/compiler/test/dotty/tools/AnnotationsTests.scala
@@ -3,15 +3,15 @@ package dotty.tools
 import org.junit.Test
 
 import java.io.File
-import java.nio.file._
+import java.nio.file.*
 
 import vulpix.TestConfiguration
-import dotc.ast.Trees._
-import dotc.core.Decorators._
-import dotc.core.Contexts._
-import dotc.core.Phases._
-import dotc.core.Types._
-import dotc.core.Symbols._
+import dotc.ast.Trees.*
+import dotc.core.Decorators.*
+import dotc.core.Contexts.*
+import dotc.core.Phases.*
+import dotc.core.Types.*
+import dotc.core.Symbols.*
 
 class AnnotationsTest:
 

--- a/compiler/test/dotty/tools/DottyTest.scala
+++ b/compiler/test/dotty/tools/DottyTest.scala
@@ -4,14 +4,14 @@ package tools
 import scala.language.unsafeNulls
 
 import vulpix.TestConfiguration
-import dotc.core._
+import dotc.core.*
 import dotc.core.Comments.{ContextDoc, ContextDocstrings}
-import dotc.core.Contexts._
-import dotc.core.Symbols._
-import Types._
-import Symbols._
-import Decorators._
-import dotc.core.Decorators._
+import dotc.core.Contexts.*
+import dotc.core.Symbols.*
+import Types.*
+import Symbols.*
+import Decorators.*
+import dotc.core.Decorators.*
 import dotc.ast.tpd
 import dotc.Compiler
 import dotc.core.Phases.Phase

--- a/compiler/test/dotty/tools/DottyTypeStealer.scala
+++ b/compiler/test/dotty/tools/DottyTypeStealer.scala
@@ -7,10 +7,10 @@ import scala.language.unsafeNulls
 import scala.util.CommandLineParser.FromString
 
 import dotc.ast.tpd
-import dotc.ast.tpd._
+import dotc.ast.tpd.*
 import dotc.core.Contexts.{Context, atPhase}
 import dotc.core.Symbols.Symbol
-import dotc.core.Decorators._
+import dotc.core.Decorators.*
 import dotc.core.Types.Type
 
 /**Pass a string representing a Scala source file,

--- a/compiler/test/dotty/tools/SignatureTest.scala
+++ b/compiler/test/dotty/tools/SignatureTest.scala
@@ -1,21 +1,21 @@
 package dotty.tools
 
-import org.junit.Assert._
+import org.junit.Assert.*
 import org.junit.Test
 
 import java.io.File
-import java.nio.file._
+import java.nio.file.*
 
 import vulpix.TestConfiguration
 import dotc.ast.untpd
-import dotc.core.Decorators._
-import dotc.core.Contexts._
-import dotc.core.Flags._
-import dotc.core.Phases._
-import dotc.core.Names._
-import dotc.core.Types._
-import dotc.core.Symbols._
-import dotc.core.StdNames._
+import dotc.core.Decorators.*
+import dotc.core.Contexts.*
+import dotc.core.Flags.*
+import dotc.core.Phases.*
+import dotc.core.Names.*
+import dotc.core.Types.*
+import dotc.core.Symbols.*
+import dotc.core.StdNames.*
 import dotc.core.Signature
 import dotc.typer.ProtoTypes.constrained
 import dotc.typer.Inferencing.isFullyDefined

--- a/compiler/test/dotty/tools/TestSources.scala
+++ b/compiler/test/dotty/tools/TestSources.scala
@@ -3,8 +3,8 @@ package dotty.tools
 import dotty.Properties
 
 import java.io.File
-import java.nio.file._
-import scala.jdk.CollectionConverters._
+import java.nio.file.*
+import scala.jdk.CollectionConverters.*
 import scala.language.unsafeNulls
 
 object TestSources {

--- a/compiler/test/dotty/tools/backend/jvm/ArrayApplyOptTest.scala
+++ b/compiler/test/dotty/tools/backend/jvm/ArrayApplyOptTest.scala
@@ -1,10 +1,10 @@
 package dotty.tools
 package backend.jvm
 
-import org.junit.Assert._
+import org.junit.Assert.*
 import org.junit.Test
 
-import scala.tools.asm.Opcodes._
+import scala.tools.asm.Opcodes.*
 
 class ArrayApplyOptTest extends DottyBytecodeTest {
   import ASMConverters._

--- a/compiler/test/dotty/tools/backend/jvm/AsmConverters.scala
+++ b/compiler/test/dotty/tools/backend/jvm/AsmConverters.scala
@@ -1,11 +1,11 @@
 package dotty.tools.backend.jvm
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.language.unsafeNulls
 import scala.tools.asm
 
-import asm._
-import asm.tree._
+import asm.*
+import asm.tree.*
 
 /** Makes using ASM from tests more convenient.
  *

--- a/compiler/test/dotty/tools/backend/jvm/AsmNode.scala
+++ b/compiler/test/dotty/tools/backend/jvm/AsmNode.scala
@@ -1,12 +1,12 @@
 package dotty.tools.backend.jvm
 
 import java.lang.reflect.Modifier
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.language.unsafeNulls
 import scala.tools.asm
 
-import asm._
-import asm.tree._
+import asm.*
+import asm.tree.*
 
 sealed trait AsmNode[+T] {
   def node: T

--- a/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTest.scala
+++ b/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTest.scala
@@ -2,25 +2,25 @@ package dotty
 package tools
 package backend.jvm
 
-import dotty.tools.io.{VirtualDirectory => Directory}
-import org.junit.Assert._
+import dotty.tools.io.VirtualDirectory as Directory
+import org.junit.Assert.*
 
+import java.io.File as JFile
 import java.io.InputStream
-import java.io.{File => JFile}
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.language.unsafeNulls
 import scala.tools.asm
 import scala.tools.asm.ClassReader
 import scala.tools.asm.ClassWriter
-import scala.tools.asm.tree._
+import scala.tools.asm.tree.*
 
 import vulpix.TestConfiguration
 import dotc.core.Contexts.{Context, ContextBase, ctx}
 import dotc.core.Comments.{ContextDoc, ContextDocstrings}
 import dotc.core.Phases.Phase
 import dotc.Compiler
-import asm._
-import asm.tree._
+import asm.*
+import asm.tree.*
 import io.{AbstractFile, JavaClassPath, VirtualDirectory}
 
 trait DottyBytecodeTest {

--- a/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTests.scala
@@ -1,16 +1,16 @@
 package dotty.tools.backend.jvm
 
-import org.junit.Assert._
+import org.junit.Assert.*
 import org.junit.Test
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.language.unsafeNulls
 import scala.tools.asm
 import scala.tools.asm.Opcodes
 
-import asm._
-import asm.tree._
-import Opcodes._
+import asm.*
+import asm.tree.*
+import Opcodes.*
 
 class DottyBytecodeTests extends DottyBytecodeTest {
   import ASMConverters._

--- a/compiler/test/dotty/tools/backend/jvm/IincTest.scala
+++ b/compiler/test/dotty/tools/backend/jvm/IincTest.scala
@@ -1,9 +1,9 @@
 package dotty.tools.backend.jvm
 
-import org.junit.Assert._
+import org.junit.Assert.*
 import org.junit.Test
 
-import scala.tools.asm.Opcodes._
+import scala.tools.asm.Opcodes.*
 
 class IincTest extends DottyBytecodeTest {
   import ASMConverters._

--- a/compiler/test/dotty/tools/backend/jvm/InlineBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/InlineBytecodeTests.scala
@@ -1,11 +1,11 @@
 package dotty.tools.backend.jvm
 
-import org.junit.Assert._
+import org.junit.Assert.*
 import org.junit.Test
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.language.unsafeNulls
-import scala.tools.asm.Opcodes._
+import scala.tools.asm.Opcodes.*
 
 class InlineBytecodeTests extends DottyBytecodeTest {
   import ASMConverters._

--- a/compiler/test/dotty/tools/backend/jvm/LabelBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/LabelBytecodeTests.scala
@@ -1,16 +1,16 @@
 package dotty.tools.backend.jvm
 
-import org.junit.Assert._
+import org.junit.Assert.*
 import org.junit.Test
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.language.unsafeNulls
 import scala.tools.asm
 import scala.tools.asm.Opcodes
 
-import asm._
-import asm.tree._
-import Opcodes._
+import asm.*
+import asm.tree.*
+import Opcodes.*
 
 class LabelBytecodeTests extends DottyBytecodeTest {
   import ASMConverters._

--- a/compiler/test/dotty/tools/backend/jvm/PublicInBinaryTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/PublicInBinaryTests.scala
@@ -1,16 +1,16 @@
 package dotty.tools.backend.jvm
 
-import org.junit.Assert._
+import org.junit.Assert.*
 import org.junit.Test
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.language.unsafeNulls
 import scala.tools.asm
 import scala.tools.asm.Opcodes
 
-import asm._
-import asm.tree._
-import Opcodes._
+import asm.*
+import asm.tree.*
+import Opcodes.*
 
 class PublicInBinaryTests extends DottyBytecodeTest {
   import ASMConverters._

--- a/compiler/test/dotty/tools/backend/jvm/StringConcatTest.scala
+++ b/compiler/test/dotty/tools/backend/jvm/StringConcatTest.scala
@@ -1,13 +1,13 @@
 package dotty.tools.backend.jvm
 
-import org.junit.Assert._
+import org.junit.Assert.*
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.asm.Opcodes._
+import scala.tools.asm.Opcodes.*
 
-import ASMConverters._
+import ASMConverters.*
 
 
 class StringConcatTest extends DottyBytecodeTest {

--- a/compiler/test/dotty/tools/backend/jvm/StringInterpolatorOptTest.scala
+++ b/compiler/test/dotty/tools/backend/jvm/StringInterpolatorOptTest.scala
@@ -1,6 +1,6 @@
 package dotty.tools.backend.jvm
 
-import org.junit.Assert._
+import org.junit.Assert.*
 import org.junit.Test
 
 class StringInterpolatorOptTest extends DottyBytecodeTest {

--- a/compiler/test/dotty/tools/compilerSupport.scala
+++ b/compiler/test/dotty/tools/compilerSupport.scala
@@ -1,16 +1,16 @@
 package dotty.tools
 
-import dotty.tools.dotc._
+import dotty.tools.dotc.*
 
-import java.io._
+import java.io.*
 import java.net.URI
-import java.nio.file._
-import javax.tools._
-import scala.jdk.CollectionConverters._
+import java.nio.file.*
+import javax.tools.*
+import scala.jdk.CollectionConverters.*
 import scala.language.unsafeNulls
 
-import core._
-import core.Contexts._
+import core.*
+import core.Contexts.*
 import dotc.core.Comments.{ContextDoc, ContextDocstrings}
 
 /** Initialize a compiler context with the given `classpath`, compile all

--- a/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
@@ -3,18 +3,18 @@ package tools
 package dotc
 
 import org.junit.AfterClass
-import org.junit.Assert._
-import org.junit.Assume._
+import org.junit.Assert.*
+import org.junit.Assume.*
 import org.junit.BeforeClass
 import org.junit.Test
 import org.junit.experimental.categories.Category
 
-import java.nio.file._
-import scala.concurrent.duration._
+import java.nio.file.*
+import scala.concurrent.duration.*
 import scala.language.unsafeNulls
 
 import reporting.TestReporter
-import vulpix._
+import vulpix.*
 
 @Category(Array(classOf[BootstrappedOnlyTests]))
 class BootstrappedOnlyCompilationTests {

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -4,24 +4,24 @@ package dotc
 
 import dotty.tools.dotc.config.ScalaSettings
 import org.junit.AfterClass
-import org.junit.Assert._
-import org.junit.Assume._
+import org.junit.Assert.*
+import org.junit.Assume.*
 import org.junit.BeforeClass
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.experimental.categories.Category
 
 import java.io.File
-import java.nio.file._
-import java.util.stream.{ Stream => JStream }
-import scala.concurrent.duration._
-import scala.jdk.CollectionConverters._
+import java.nio.file.*
+import java.util.stream.Stream as JStream
+import scala.concurrent.duration.*
+import scala.jdk.CollectionConverters.*
 import scala.language.unsafeNulls
 import scala.util.matching.Regex
 
 import TestSources.sources
 import reporting.TestReporter
-import vulpix._
+import vulpix.*
 
 class CompilationTests {
   import ParallelTesting._

--- a/compiler/test/dotty/tools/dotc/ConstantFoldingTests.scala
+++ b/compiler/test/dotty/tools/dotc/ConstantFoldingTests.scala
@@ -1,12 +1,12 @@
 package dotty.tools.dotc
 
-import dotty.tools.backend.jvm._
+import dotty.tools.backend.jvm.*
 import dotty.tools.dotc.config.CompilerCommand
 import dotty.tools.dotc.core.Contexts.FreshContext
-import org.junit.Assert._
+import org.junit.Assert.*
 import org.junit.Test
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.language.unsafeNulls
 import scala.tools.asm.tree.MethodNode
 

--- a/compiler/test/dotty/tools/dotc/FromTastyTests.scala
+++ b/compiler/test/dotty/tools/dotc/FromTastyTests.scala
@@ -5,12 +5,12 @@ package dotc
 import org.junit.AfterClass
 import org.junit.Test
 
-import java.io.{File => JFile}
-import scala.concurrent.duration._
+import java.io.File as JFile
+import scala.concurrent.duration.*
 import scala.language.unsafeNulls
 
 import reporting.TestReporter
-import vulpix._
+import vulpix.*
 
 class FromTastyTests {
   import TestConfiguration._

--- a/compiler/test/dotty/tools/dotc/IdempotencyTests.scala
+++ b/compiler/test/dotty/tools/dotc/IdempotencyTests.scala
@@ -7,15 +7,15 @@ import org.junit.Assume.assumeTrue
 import org.junit.Test
 import org.junit.experimental.categories.Category
 
-import java.io.{File => JFile}
+import java.io.File as JFile
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import scala.language.unsafeNulls
 
 import reporting.TestReporter
-import vulpix._
+import vulpix.*
 
 
 class IdempotencyTests {

--- a/compiler/test/dotty/tools/dotc/InterfaceEntryPointTest.scala
+++ b/compiler/test/dotty/tools/dotc/InterfaceEntryPointTest.scala
@@ -1,15 +1,15 @@
 package dotty
 package tools.dotc
 
-import org.junit.Assert._
+import org.junit.Assert.*
 import org.junit.Test
 import org.junit.experimental.categories.Category
 
-import java.nio.file._
+import java.nio.file.*
 import scala.collection.mutable.ListBuffer
 import scala.language.unsafeNulls
 
-import interfaces._
+import interfaces.*
 
 /** Test that demonstrates how to use dotty-interfaces
  *

--- a/compiler/test/dotty/tools/dotc/Playground.scala
+++ b/compiler/test/dotty/tools/dotc/Playground.scala
@@ -1,6 +1,6 @@
 package dotty.tools.dotc
 
-import dotty.tools.vulpix._
+import dotty.tools.vulpix.*
 import org.junit.Ignore
 import org.junit.Test
 

--- a/compiler/test/dotty/tools/dotc/ScalaCommandTest.scala
+++ b/compiler/test/dotty/tools/dotc/ScalaCommandTest.scala
@@ -1,7 +1,7 @@
 package dotty.tools.dotc
 
-import dotty.tools.dotc.config.Settings._
-import org.junit.Assert._
+import dotty.tools.dotc.config.Settings.*
+import org.junit.Assert.*
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder

--- a/compiler/test/dotty/tools/dotc/SettingsTests.scala
+++ b/compiler/test/dotty/tools/dotc/SettingsTests.scala
@@ -1,12 +1,12 @@
 package dotty.tools
 package dotc
 
-import dotty.tools.dotc.config.Settings._
+import dotty.tools.dotc.config.Settings.*
 import dotty.tools.vulpix.TestConfiguration.mkClasspath
-import org.junit.Assert._
+import org.junit.Assert.*
 import org.junit.Test
 
-import java.nio.file._
+import java.nio.file.*
 import scala.language.unsafeNulls
 
 import reporting.StoreReporter

--- a/compiler/test/dotty/tools/dotc/TastyBootstrapTests.scala
+++ b/compiler/test/dotty/tools/dotc/TastyBootstrapTests.scala
@@ -3,22 +3,22 @@ package tools
 package dotc
 
 import org.junit.AfterClass
-import org.junit.Assert._
-import org.junit.Assume._
+import org.junit.Assert.*
+import org.junit.Assume.*
 import org.junit.BeforeClass
 import org.junit.Test
 import org.junit.experimental.categories.Category
 
 import java.io.File
-import java.nio.file._
-import java.util.stream.{ Stream => JStream }
-import scala.concurrent.duration._
-import scala.jdk.CollectionConverters._
+import java.nio.file.*
+import java.util.stream.Stream as JStream
+import scala.concurrent.duration.*
+import scala.jdk.CollectionConverters.*
 import scala.language.unsafeNulls
 import scala.util.matching.Regex
 
 import TestSources.sources
-import vulpix._
+import vulpix.*
 import reporting.TestReporter
 
 class TastyBootstrapTests {

--- a/compiler/test/dotty/tools/dotc/TupleShowTests.scala
+++ b/compiler/test/dotty/tools/dotc/TupleShowTests.scala
@@ -3,7 +3,7 @@ package dotc
 
 import org.junit.Test
 
-import java.lang.System.{ lineSeparator => EOL }
+import java.lang.System.lineSeparator as EOL
 
 import core.*
 import Decorators.*

--- a/compiler/test/dotty/tools/dotc/ast/AttachmentsTest.scala
+++ b/compiler/test/dotty/tools/dotc/ast/AttachmentsTest.scala
@@ -1,7 +1,7 @@
 package dotty.tools.dotc.ast
 
 import dotty.tools.DottyTest
-import dotty.tools.dotc.ast.Trees._
+import dotty.tools.dotc.ast.Trees.*
 import dotty.tools.dotc.util.Property
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue

--- a/compiler/test/dotty/tools/dotc/ast/DesugarTests.scala
+++ b/compiler/test/dotty/tools/dotc/ast/DesugarTests.scala
@@ -4,13 +4,13 @@ package ast
 
 import org.junit.Test
 
-import core._
-import Names._
-import Types._
-import Symbols._
-import StdNames._
-import Flags._
-import Contexts._
+import core.*
+import Names.*
+import Types.*
+import Symbols.*
+import StdNames.*
+import Flags.*
+import Contexts.*
 
 class DesugarTests extends DottyTest {
   import tpd._

--- a/compiler/test/dotty/tools/dotc/ast/TreeInfoTest.scala
+++ b/compiler/test/dotty/tools/dotc/ast/TreeInfoTest.scala
@@ -2,12 +2,12 @@ package dotty.tools
 package dotc
 package ast
 
-import org.junit.Assert._
+import org.junit.Assert.*
 import org.junit.Test
 
-import core.Names._
+import core.Names.*
 import core.StdNames.nme
-import core.Symbols._
+import core.Symbols.*
 import core.Contexts.Context
 
 class TreeInfoTest extends DottyTest {

--- a/compiler/test/dotty/tools/dotc/ast/UntypedTreeMapTest.scala
+++ b/compiler/test/dotty/tools/dotc/ast/UntypedTreeMapTest.scala
@@ -2,10 +2,10 @@ package dotty.tools
 package dotc
 package ast
 
-import org.junit.Assert._
+import org.junit.Assert.*
 import org.junit.Test
 
-import dotc.core.Contexts._
+import dotc.core.Contexts.*
 import dotc.parsing.Parsers.Parser
 import dotc.util.SourceFile
 

--- a/compiler/test/dotty/tools/dotc/classpath/JrtClassPathTest.scala
+++ b/compiler/test/dotty/tools/dotc/classpath/JrtClassPathTest.scala
@@ -10,7 +10,7 @@ import dotty.tools.dotc.config.PathResolver
 import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.core.Contexts.ContextBase
 import dotty.tools.io.ClassPath
-import org.junit.Assert._
+import org.junit.Assert.*
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4

--- a/compiler/test/dotty/tools/dotc/classpath/MultiReleaseJarTest.scala
+++ b/compiler/test/dotty/tools/dotc/classpath/MultiReleaseJarTest.scala
@@ -1,7 +1,7 @@
 package dotty.tools.dotc.classpath
 
 import dotty.tools.dotc.core.Contexts.Context
-import org.junit.Assert._
+import org.junit.Assert.*
 import org.junit.Test
 
 import java.io.ByteArrayOutputStream
@@ -11,7 +11,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.util.jar.Attributes
 import java.util.jar.Attributes.Name
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.language.unsafeNulls
 import scala.util.Properties
 

--- a/compiler/test/dotty/tools/dotc/classpath/ZipAndJarFileLookupFactoryTest.scala
+++ b/compiler/test/dotty/tools/dotc/classpath/ZipAndJarFileLookupFactoryTest.scala
@@ -6,7 +6,7 @@ import dotty.tools.dotc.core.Contexts.ctx
 import dotty.tools.io.AbstractFile
 import org.junit.Test
 
-import java.nio.file._
+import java.nio.file.*
 import java.nio.file.attribute.FileTime
 import scala.language.unsafeNulls
 

--- a/compiler/test/dotty/tools/dotc/config/ScalaSettingsTests.scala
+++ b/compiler/test/dotty/tools/dotc/config/ScalaSettingsTests.scala
@@ -1,11 +1,11 @@
 package dotty.tools.dotc
 package config
 
-import org.junit.Assert._
+import org.junit.Assert.*
 import org.junit.Test
 
 import CommandLineParser.tokenize
-import Settings._
+import Settings.*
 import core.Decorators.toMessage
 
 class ScalaSettingsTests:

--- a/compiler/test/dotty/tools/dotc/core/SealedDescendantsTest.scala
+++ b/compiler/test/dotty/tools/dotc/core/SealedDescendantsTest.scala
@@ -3,7 +3,7 @@ package dotty.tools.dotc.core
 import dotty.tools.DottyTest
 import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.core.Symbols.*
-import org.junit.Assert._
+import org.junit.Assert.*
 import org.junit.Test
 
 class SealedDescendantsTest extends DottyTest {

--- a/compiler/test/dotty/tools/dotc/core/tasty/PathPicklingTest.scala
+++ b/compiler/test/dotty/tools/dotc/core/tasty/PathPicklingTest.scala
@@ -24,13 +24,13 @@ import org.junit.Assert.fail
 import org.junit.Test
 
 import java.io.ByteArrayOutputStream
+import java.io.File as JFile
 import java.io.IOException
-import java.io.{File => JFile}
 import java.nio.file.Files
 import java.nio.file.NoSuchFileException
 import java.nio.file.Paths
 import scala.language.unsafeNulls
-import scala.sys.process._
+import scala.sys.process.*
 
 class PathPicklingTest {
 

--- a/compiler/test/dotty/tools/dotc/core/tasty/TastyHeaderUnpicklerTest.scala
+++ b/compiler/test/dotty/tools/dotc/core/tasty/TastyHeaderUnpicklerTest.scala
@@ -1,14 +1,14 @@
 package dotty.tools.dotc.core.tasty
 
 import dotty.tools.tasty.TastyBuffer
-import dotty.tools.tasty.TastyBuffer._
-import dotty.tools.tasty.TastyFormat._
+import dotty.tools.tasty.TastyBuffer.*
+import dotty.tools.tasty.TastyFormat.*
 import dotty.tools.tasty.TastyHeaderUnpickler
 import dotty.tools.tasty.TastyReader
 import dotty.tools.tasty.TastyVersion
 import dotty.tools.tasty.UnpickleException
 import dotty.tools.tasty.UnpicklerConfig
-import org.junit.Assert._
+import org.junit.Assert.*
 import org.junit.Ignore
 import org.junit.Test
 

--- a/compiler/test/dotty/tools/dotc/coverage/CoverageTests.scala
+++ b/compiler/test/dotty/tools/dotc/coverage/CoverageTests.scala
@@ -5,8 +5,8 @@ import dotty.Properties
 import dotty.tools.dotc.Main
 import dotty.tools.dotc.reporting.TestReporter
 import dotty.tools.dotc.util.DiffUtil
-import dotty.tools.vulpix.TestConfiguration.*
 import dotty.tools.vulpix.*
+import dotty.tools.vulpix.TestConfiguration.*
 import org.junit.AfterClass
 import org.junit.Assert.*
 import org.junit.Assume.*

--- a/compiler/test/dotty/tools/dotc/interactive/CustomCompletion.scala
+++ b/compiler/test/dotty/tools/dotc/interactive/CustomCompletion.scala
@@ -1,11 +1,11 @@
 package dotty.tools.dotc.interactive
 
-import dotty.tools.dotc.ast.tpd._
+import dotty.tools.dotc.ast.tpd.*
 import dotty.tools.dotc.ast.untpd
-import dotty.tools.dotc.core.Contexts._
+import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.Denotations.SingleDenotation
-import dotty.tools.dotc.core.Flags._
-import dotty.tools.dotc.core.NameOps._
+import dotty.tools.dotc.core.Flags.*
+import dotty.tools.dotc.core.NameOps.*
 import dotty.tools.dotc.core.Names.Name
 import dotty.tools.dotc.core.Names.termName
 import dotty.tools.dotc.core.StdNames.nme

--- a/compiler/test/dotty/tools/dotc/parsing/DeSugarTest.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/DeSugarTest.scala
@@ -2,10 +2,10 @@ package dotty.tools
 package dotc
 package parsing
 
-import Tokens._
-import Parsers._
-import core._
-import ast.Trees._
+import Tokens.*
+import Parsers.*
+import core.*
+import ast.Trees.*
 import ast.desugar
 import core.Mode
 import Contexts.Context

--- a/compiler/test/dotty/tools/dotc/parsing/DocstringTest.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/DocstringTest.scala
@@ -2,7 +2,7 @@ package dotty.tools
 package dotc
 package parsing
 
-import ast.Trees._
+import ast.Trees.*
 import core.Contexts.Context
 
 trait DocstringTest extends DottyTest {

--- a/compiler/test/dotty/tools/dotc/parsing/DocstringTests.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/DocstringTests.scala
@@ -2,8 +2,8 @@ package dotty.tools
 package dotc
 package parsing
 
-import dotty.tools.dotc.ast.Trees._
-import org.junit.Assert._
+import dotty.tools.dotc.ast.Trees.*
+import org.junit.Assert.*
 import org.junit.Test
 
 class DocstringTests extends DocstringTest {

--- a/compiler/test/dotty/tools/dotc/parsing/ModifiersParsingTest.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/ModifiersParsingTest.scala
@@ -2,15 +2,15 @@ package dotty.tools
 package dotc
 package parsing
 
-import org.junit.Assert._
+import org.junit.Assert.*
 import org.junit.Test
 
 import ast.Trees.mods
-import ast.untpd._
-import ast.{ Trees => d }
+import ast.untpd.*
+import ast.Trees as d
 import Parsers.Parser
 import util.SourceFile
-import core.Contexts._
+import core.Contexts.*
 import core.Flags
 
 object ModifiersParsingTest {

--- a/compiler/test/dotty/tools/dotc/parsing/ParserEdgeTest.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/ParserEdgeTest.scala
@@ -4,8 +4,8 @@ package parsing
 
 import org.junit.Test
 
-import ast.untpd._
-import core.Constants._
+import ast.untpd.*
+import core.Constants.*
 
 class ParserEdgeTest extends ParserTest {
   //

--- a/compiler/test/dotty/tools/dotc/parsing/ParserTest.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/ParserTest.scala
@@ -2,15 +2,15 @@ package dotty.tools
 package dotc
 package parsing
 
-import dotty.tools.io._
+import dotty.tools.io.*
 
 import scala.collection.mutable.ListBuffer
 import scala.io.Codec
 
-import util._
-import Tokens._
-import Parsers._
-import ast.untpd._
+import util.*
+import Tokens.*
+import Parsers.*
+import ast.untpd.*
 
 class ParserTest extends DottyTest {
 

--- a/compiler/test/dotty/tools/dotc/parsing/ScannerTest.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/ScannerTest.scala
@@ -2,14 +2,14 @@ package dotty.tools
 package dotc
 package parsing
 
-import dotty.tools.io._
+import dotty.tools.io.*
 import org.junit.Test
 
 import scala.io.Codec
 
-import util._
-import Tokens._
-import Scanners._
+import util.*
+import Tokens.*
+import Scanners.*
 
 class ScannerTest extends DottyTest {
 

--- a/compiler/test/dotty/tools/dotc/parsing/StringInterpolationPositionTest.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/StringInterpolationPositionTest.scala
@@ -4,7 +4,7 @@ package parsing
 
 import org.junit.Test
 
-import ast.untpd._
+import ast.untpd.*
 
 class StringInterpolationPositionTest extends ParserTest {
 

--- a/compiler/test/dotty/tools/dotc/parsing/desugarPackage.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/desugarPackage.scala
@@ -2,8 +2,8 @@ package dotty.tools
 package dotc
 package parsing
 
-import core._
-import ast._
+import core.*
+import ast.*
 
 object desugarPackage extends DeSugarTest {
 

--- a/compiler/test/dotty/tools/dotc/parsing/parsePackage.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/parsePackage.scala
@@ -2,11 +2,11 @@ package dotty.tools
 package dotc
 package parsing
 
-import dotty.tools.dotc._
+import dotty.tools.dotc.*
 
-import core._
-import ast._
-import Trees._
+import core.*
+import ast.*
+import Trees.*
 import Contexts.Context
 
 object parsePackage extends ParserTest {

--- a/compiler/test/dotty/tools/dotc/plugins/PluginsTest.scala
+++ b/compiler/test/dotty/tools/dotc/plugins/PluginsTest.scala
@@ -1,11 +1,11 @@
 package dotty.tools.dotc.plugins
 
-import dotty.tools.dotc._
+import dotty.tools.dotc.*
 import org.junit.Test
 
 import scala.language.unsafeNulls
 
-import plugins._
+import plugins.*
 import transform.MegaPhase.MiniPhase
 import core.Phases.Phase
 

--- a/compiler/test/dotty/tools/dotc/printing/PrintingTest.scala
+++ b/compiler/test/dotty/tools/dotc/printing/PrintingTest.scala
@@ -5,11 +5,11 @@ package dotc
 import dotty.tools.io.Directory
 import org.junit.Test
 
+import java.io.*
 import java.io.File
-import java.io._
-import java.lang.System.{lineSeparator => EOL}
+import java.lang.System.lineSeparator as EOL
 import java.nio.charset.StandardCharsets
-import java.nio.file.{Path => JPath}
+import java.nio.file.Path as JPath
 import scala.io.Source
 import scala.language.unsafeNulls
 import scala.util.Using

--- a/compiler/test/dotty/tools/dotc/printing/SyntaxHighlightingTests.scala
+++ b/compiler/test/dotty/tools/dotc/printing/SyntaxHighlightingTests.scala
@@ -1,7 +1,7 @@
 package dotty.tools.dotc.printing
 
 import dotty.tools.DottyTest
-import org.junit.Assert._
+import org.junit.Assert.*
 import org.junit.Ignore
 import org.junit.Test
 

--- a/compiler/test/dotty/tools/dotc/reporting/CodeActionTest.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/CodeActionTest.scala
@@ -4,7 +4,7 @@ import dotty.tools.DottyTest
 import dotty.tools.dotc.rewrites.Rewrites
 import dotty.tools.dotc.rewrites.Rewrites.ActionPatch
 import dotty.tools.dotc.util.SourceFile
-import org.junit.Assert._
+import org.junit.Assert.*
 import org.junit.Test
 
 import scala.annotation.tailrec

--- a/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTest.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/ErrorMessagesTest.scala
@@ -2,7 +2,7 @@ package dotty.tools
 package dotc
 package reporting
 
-import org.junit.Assert._
+import org.junit.Assert.*
 
 import scala.language.unsafeNulls
 

--- a/compiler/test/dotty/tools/dotc/reporting/TestReporter.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/TestReporter.scala
@@ -5,6 +5,7 @@ package reporting
 import dotty.Properties
 
 import java.io.BufferedReader
+import java.io.File as JFile
 import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.io.FileReader
@@ -12,7 +13,6 @@ import java.io.PrintStream
 import java.io.PrintWriter
 import java.io.StringReader
 import java.io.StringWriter
-import java.io.{File => JFile}
 import java.text.SimpleDateFormat
 import java.util.Date
 import scala.collection.mutable

--- a/compiler/test/dotty/tools/dotc/reporting/UserDefinedErrorMessages.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/UserDefinedErrorMessages.scala
@@ -3,7 +3,7 @@ package dotc
 package reporting
 
 import dotty.tools.dotc.core.Contexts.Context
-import org.junit.Assert._
+import org.junit.Assert.*
 import org.junit.Test
 
 class UserDefinedErrorMessages extends ErrorMessagesTest {

--- a/compiler/test/dotty/tools/dotc/semanticdb/SemanticdbTests.scala
+++ b/compiler/test/dotty/tools/dotc/semanticdb/SemanticdbTests.scala
@@ -4,20 +4,20 @@ import dotty.BootstrappedOnlyTests
 import dotty.tools.dotc.Main
 import dotty.tools.dotc.semanticdb.Scala3.given
 import dotty.tools.dotc.util.SourceFile
-import org.junit.Assert._
+import org.junit.Assert.*
 import org.junit.Test
 import org.junit.experimental.categories.Category
 
 import java.io.File
 import java.net.URLClassLoader
 import java.nio.charset.StandardCharsets
-import java.nio.file._
+import java.nio.file.*
 import java.util.Comparator
 import java.util.regex.Pattern
 import java.util.stream.Collectors
 import javax.tools.ToolProvider
 import scala.collection.mutable
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.language.unsafeNulls
 import scala.util.control.NonFatal
 

--- a/compiler/test/dotty/tools/dotc/transform/CreateCompanionObjectsTest.scala
+++ b/compiler/test/dotty/tools/dotc/transform/CreateCompanionObjectsTest.scala
@@ -2,7 +2,7 @@ package dotty.tools
 package dotc
 package transform
 
-import core._
+import core.*
 import ast.Trees
 
 

--- a/compiler/test/dotty/tools/dotc/transform/PatmatExhaustivityTest.scala
+++ b/compiler/test/dotty/tools/dotc/transform/PatmatExhaustivityTest.scala
@@ -6,8 +6,8 @@ package transform
 import dotty.tools.io.Directory
 import org.junit.Test
 
-import java.io._
-import java.nio.file.{Path => JPath}
+import java.io.*
+import java.nio.file.Path as JPath
 import scala.language.unsafeNulls
 
 import vulpix.FileDiff

--- a/compiler/test/dotty/tools/dotc/transform/PostTyperTransformerTest.scala
+++ b/compiler/test/dotty/tools/dotc/transform/PostTyperTransformerTest.scala
@@ -2,7 +2,7 @@ package dotty.tools
 package dotc
 package transform
 
-import core._
+import core.*
 import ast.Trees
 
 class PostTyperTransformerTest extends DottyTest {

--- a/compiler/test/dotty/tools/dotc/transform/TreeTransformerTest.scala
+++ b/compiler/test/dotty/tools/dotc/transform/TreeTransformerTest.scala
@@ -5,7 +5,7 @@ package transform
 import org.junit.Assert
 import org.junit.Test
 
-import MegaPhase._
+import MegaPhase.*
 import ast.tpd
 import core.Constants.Constant
 import core.Contexts.Context

--- a/compiler/test/dotty/tools/dotc/typer/DivergenceChecker.scala
+++ b/compiler/test/dotty/tools/dotc/typer/DivergenceChecker.scala
@@ -1,7 +1,7 @@
 package dotty.tools.dotc.typer
 
 import dotty.tools.DottyTest
-import dotty.tools.dotc.core.Contexts._
+import dotty.tools.dotc.core.Contexts.*
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test

--- a/compiler/test/dotty/tools/dotc/util/DiffUtilTests.scala
+++ b/compiler/test/dotty/tools/dotc/util/DiffUtilTests.scala
@@ -1,6 +1,6 @@
 package dotty.tools.dotc.util
 
-import org.junit.Assert._
+import org.junit.Assert.*
 import org.junit.Test
 
 import scala.language.unsafeNulls

--- a/compiler/test/dotty/tools/io/AbstractFileTest.scala
+++ b/compiler/test/dotty/tools/io/AbstractFileTest.scala
@@ -3,7 +3,7 @@ package dotty.tools.io
 import dotty.tools.io.AbstractFile
 import org.junit.Test
 
-import java.nio.file.Files._
+import java.nio.file.Files.*
 import java.nio.file.attribute.PosixFilePermissions
 import scala.language.unsafeNulls
 

--- a/compiler/test/dotty/tools/io/ClasspathTest.scala
+++ b/compiler/test/dotty/tools/io/ClasspathTest.scala
@@ -9,7 +9,7 @@ import org.junit.Test
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
-import java.nio.file.StandardCopyOption._
+import java.nio.file.StandardCopyOption.*
 import java.nio.file.attribute.PosixFilePermissions
 import scala.language.unsafeNulls
 

--- a/compiler/test/dotty/tools/io/ZipArchiveTest.scala
+++ b/compiler/test/dotty/tools/io/ZipArchiveTest.scala
@@ -1,6 +1,6 @@
 package dotty.tools.io
 
-import org.junit.Assert._
+import org.junit.Assert.*
 import org.junit.Test
 
 import java.io.IOException
@@ -18,7 +18,7 @@ import java.util.jar.JarOutputStream
 import java.util.jar.Manifest
 import scala.language.unsafeNulls
 import scala.util.Using
-import scala.util.chaining._
+import scala.util.chaining.*
 
 class ZipArchiveTest {
 

--- a/compiler/test/dotty/tools/repl/JavaDefinedTests.scala
+++ b/compiler/test/dotty/tools/repl/JavaDefinedTests.scala
@@ -1,6 +1,6 @@
 package dotty.tools.repl
 
-import org.junit.Assert._
+import org.junit.Assert.*
 import org.junit.Test
 
 class JavaDefinedTests extends ReplTest {

--- a/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
+++ b/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
@@ -1,7 +1,7 @@
 package dotty.tools.repl
 
 import dotty.tools.dotc.core.Contexts.Context
-import org.junit.Assert.{assertTrue => assert, _}
+import org.junit.Assert.{assertTrue as assert, *}
 import org.junit.Ignore
 import org.junit.Test
 

--- a/compiler/test/dotty/tools/repl/ReplTest.scala
+++ b/compiler/test/dotty/tools/repl/ReplTest.scala
@@ -4,13 +4,13 @@ package repl
 import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.reporting.MessageRendering
 import org.junit.After
-import org.junit.Assert._
+import org.junit.Assert.*
 import org.junit.Before
 
 import java.io.ByteArrayOutputStream
+import java.io.File as JFile
 import java.io.PrintStream
-import java.io.{File => JFile}
-import java.lang.System.{lineSeparator => EOL}
+import java.lang.System.lineSeparator as EOL
 import java.nio.charset.StandardCharsets
 import scala.collection.mutable.ArrayBuffer
 import scala.io.Source

--- a/compiler/test/dotty/tools/repl/ShadowingBatchTests.scala
+++ b/compiler/test/dotty/tools/repl/ShadowingBatchTests.scala
@@ -3,7 +3,7 @@ package repl
 
 import org.junit.After
 import org.junit.AfterClass
-import org.junit.Assert._
+import org.junit.Assert.*
 import org.junit.BeforeClass
 import org.junit.Test
 
@@ -12,7 +12,7 @@ import java.nio.file.Files
 import scala.language.unsafeNulls
 
 import io.{ Directory, PlainDirectory }
-import dotc.core.Contexts._
+import dotc.core.Contexts.*
 import dotc.reporting.{ ErrorMessagesTest, StoreReporter }
 
 object ShadowingBatchTests:

--- a/compiler/test/dotty/tools/repl/TabcompleteTests.scala
+++ b/compiler/test/dotty/tools/repl/TabcompleteTests.scala
@@ -1,6 +1,6 @@
 package dotty.tools.repl
 
-import org.junit.Assert._
+import org.junit.Assert.*
 import org.junit.Test
 
 import scala.language.unsafeNulls

--- a/compiler/test/dotty/tools/utils.scala
+++ b/compiler/test/dotty/tools/utils.scala
@@ -5,9 +5,9 @@ import java.io.File
 import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.Files
-import java.nio.file.{Path => JPath}
+import java.nio.file.Path as JPath
 import scala.io.Source
-import scala.jdk.StreamConverters._
+import scala.jdk.StreamConverters.*
 import scala.language.unsafeNulls
 import scala.reflect.ClassTag
 import scala.util.Using.resource

--- a/compiler/test/dotty/tools/vulpix/FileDiff.scala
+++ b/compiler/test/dotty/tools/vulpix/FileDiff.scala
@@ -1,7 +1,7 @@
 package dotty.tools.vulpix
 
 import java.io.File
-import java.lang.System.{lineSeparator => EOL}
+import java.lang.System.lineSeparator as EOL
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Paths

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -5,10 +5,10 @@ package vulpix
 import dotty.tools.vulpix.TestConfiguration.defaultOptions
 
 import java.io.ByteArrayOutputStream
+import java.io.File as JFile
 import java.io.IOException
 import java.io.PrintStream
-import java.io.{File => JFile}
-import java.lang.System.{lineSeparator => EOL}
+import java.lang.System.lineSeparator as EOL
 import java.net.URL
 import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
@@ -22,22 +22,22 @@ import java.util.HashMap
 import java.util.Timer
 import java.util.TimerTask
 import java.util.concurrent.ExecutionException
+import java.util.concurrent.Executors as JExecutors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
-import java.util.concurrent.{Executors => JExecutors}
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.io.Codec
 import scala.io.Source
 import scala.jdk.CollectionConverters.*
 import scala.language.unsafeNulls
+import scala.util.Failure as TryFailure
 import scala.util.Random
+import scala.util.Success as TrySuccess
 import scala.util.Try
 import scala.util.Using
 import scala.util.control.NonFatal
 import scala.util.matching.Regex
-import scala.util.{Failure => TryFailure}
-import scala.util.{Success => TrySuccess}
 
 import dotc.{Compiler, Driver}
 import dotc.core.Contexts.*

--- a/compiler/test/dotty/tools/vulpix/RunnerOrchestration.scala
+++ b/compiler/test/dotty/tools/vulpix/RunnerOrchestration.scala
@@ -3,9 +3,9 @@ package tools
 package vulpix
 
 import java.io.BufferedReader
+import java.io.File as JFile
 import java.io.InputStreamReader
 import java.io.PrintStream
-import java.io.{File => JFile}
 import java.nio.charset.StandardCharsets
 import java.nio.file.Paths
 import java.util.concurrent.TimeoutException

--- a/compiler/test/dotty/tools/vulpix/TestFlags.scala
+++ b/compiler/test/dotty/tools/vulpix/TestFlags.scala
@@ -1,6 +1,6 @@
 package dotty.tools.vulpix
 
-import java.io.{File => JFile}
+import java.io.File as JFile
 import scala.language.unsafeNulls
 
 final case class TestFlags(

--- a/compiler/test/dotty/tools/vulpix/VulpixMetaTests.scala
+++ b/compiler/test/dotty/tools/vulpix/VulpixMetaTests.scala
@@ -5,9 +5,9 @@ import org.junit.AfterClass
 import org.junit.Test
 import org.junit.experimental.categories.Category
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
-import TestConfiguration._
+import TestConfiguration.*
 
 /** Meta tests for the Vulpix test suite. This test follows the structure of
  *  CompilationTests.scala. It is meant to be called from bash to diff with

--- a/compiler/test/dotty/tools/vulpix/VulpixUnitTests.scala
+++ b/compiler/test/dotty/tools/vulpix/VulpixUnitTests.scala
@@ -2,11 +2,11 @@ package dotty.tools
 package vulpix
 
 import org.junit.AfterClass
-import org.junit.Assert._
+import org.junit.Assert.*
 import org.junit.Test
 
-import java.io.{File => JFile}
-import scala.concurrent.duration._
+import java.io.File as JFile
+import scala.concurrent.duration.*
 import scala.language.unsafeNulls
 import scala.util.control.NonFatal
 

--- a/library/src/scala/runtime/Arrays.scala
+++ b/library/src/scala/runtime/Arrays.scala
@@ -1,6 +1,6 @@
 package scala.runtime
 
-import java.lang.{reflect => jlr}
+import java.lang.reflect as jlr
 import scala.reflect.ClassTag
 
 /** All but the first two operations should be short-circuited and implemented specially by

--- a/presentation-compiler/src/main/dotty/tools/pc/ExtractMethodProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/ExtractMethodProvider.scala
@@ -15,16 +15,16 @@ import dotty.tools.dotc.util.SourcePosition
 import dotty.tools.pc.printer.ShortenedTypePrinter
 import dotty.tools.pc.printer.ShortenedTypePrinter.IncludeDefaultParam
 import dotty.tools.pc.utils.MtagsEnrichments.*
-import org.eclipse.lsp4j.TextEdit
 import org.eclipse.lsp4j as l
+import org.eclipse.lsp4j.TextEdit
 
 import java.nio.file.Paths
+import scala.meta as m
 import scala.meta.internal.metals.ReportContext
 import scala.meta.internal.pc.ExtractMethodUtils
 import scala.meta.pc.OffsetParams
 import scala.meta.pc.RangeParams
 import scala.meta.pc.SymbolSearch
-import scala.meta as m
 
 final class ExtractMethodProvider(
     range: RangeParams,

--- a/presentation-compiler/src/main/dotty/tools/pc/InferredTypeProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/InferredTypeProvider.scala
@@ -16,16 +16,16 @@ import dotty.tools.dotc.util.Spans.Span
 import dotty.tools.pc.printer.ShortenedTypePrinter
 import dotty.tools.pc.printer.ShortenedTypePrinter.IncludeDefaultParam
 import dotty.tools.pc.utils.MtagsEnrichments.*
-import org.eclipse.lsp4j.TextEdit
 import org.eclipse.lsp4j as l
+import org.eclipse.lsp4j.TextEdit
 
 import java.nio.file.Paths
 import scala.annotation.tailrec
+import scala.meta as m
 import scala.meta.internal.metals.ReportContext
 import scala.meta.pc.OffsetParams
 import scala.meta.pc.PresentationCompilerConfig
 import scala.meta.pc.SymbolSearch
-import scala.meta as m
 
 /**
  * Tries to calculate edits needed to insert the inferred type annotation

--- a/presentation-compiler/src/main/dotty/tools/pc/PcCollector.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/PcCollector.scala
@@ -22,10 +22,10 @@ import dotty.tools.dotc.util.Spans.Span
 import dotty.tools.pc.utils.MtagsEnrichments.*
 
 import java.nio.file.Paths
+import scala.meta as m
 import scala.meta.internal.metals.CompilerOffsetParams
 import scala.meta.pc.OffsetParams
 import scala.meta.pc.VirtualFileParams
-import scala.meta as m
 
 abstract class PcCollector[T](
     driver: InteractiveDriver,

--- a/presentation-compiler/src/main/dotty/tools/pc/ScalaPresentationCompiler.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/ScalaPresentationCompiler.scala
@@ -4,21 +4,21 @@ import dotty.tools.dotc.reporting.StoreReporter
 import dotty.tools.pc.buildinfo.BuildInfo
 import dotty.tools.pc.completions.CompletionProvider
 import dotty.tools.pc.completions.OverrideCompletions
+import org.eclipse.lsp4j as l
 import org.eclipse.lsp4j.DocumentHighlight
 import org.eclipse.lsp4j.TextEdit
-import org.eclipse.lsp4j as l
 
 import java.io.File
 import java.net.URI
 import java.nio.file.Path
+import java.util as ju
 import java.util.Optional
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.ScheduledExecutorService
-import java.util as ju
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContextExecutor
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.language.unsafeNulls
 import scala.meta.internal.metals.CompilerVirtualFileParams
 import scala.meta.internal.metals.EmptyCancelToken

--- a/presentation-compiler/src/main/dotty/tools/pc/SelectionRangeProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/SelectionRangeProvider.scala
@@ -10,7 +10,7 @@ import org.eclipse.lsp4j.SelectionRange
 
 import java.nio.file.Paths
 import java.util as ju
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.meta.pc.OffsetParams
 
 /**

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/AmmoniteFileCompletions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/AmmoniteFileCompletions.scala
@@ -1,8 +1,8 @@
 package dotty.tools.pc
 package completions
 
-import dotty.tools.dotc.ast.tpd.Tree
 import dotty.tools.dotc.ast.tpd.*
+import dotty.tools.dotc.ast.tpd.Tree
 import dotty.tools.dotc.ast.untpd.ImportSelector
 import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.core.StdNames.*
@@ -11,7 +11,7 @@ import org.eclipse.lsp4j as l
 
 import java.nio.file.Files
 import java.nio.file.Path
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.meta.internal.pc.CompletionFuzzy
 
 object AmmoniteFileCompletions:

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionProvider.scala
@@ -20,11 +20,11 @@ import org.eclipse.lsp4j.CompletionItemKind
 import org.eclipse.lsp4j.CompletionList
 import org.eclipse.lsp4j.InsertTextFormat
 import org.eclipse.lsp4j.InsertTextMode
-import org.eclipse.lsp4j.TextEdit
 import org.eclipse.lsp4j.Range as LspRange
+import org.eclipse.lsp4j.TextEdit
 
 import java.nio.file.Path
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.meta.internal.metals.ReportContext
 import scala.meta.pc.OffsetParams
 import scala.meta.pc.PresentationCompilerConfig

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/MatchCaseCompletions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/MatchCaseCompletions.scala
@@ -26,7 +26,7 @@ import org.eclipse.lsp4j as l
 import java.net.URI
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.meta.internal.pc.CompletionFuzzy
 import scala.meta.pc.PresentationCompilerConfig
 import scala.meta.pc.SymbolSearch

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/OverrideCompletions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/OverrideCompletions.scala
@@ -1,8 +1,8 @@
 package dotty.tools.pc
 package completions
 
-import dotty.tools.dotc.ast.tpd.Tree
 import dotty.tools.dotc.ast.tpd.*
+import dotty.tools.dotc.ast.tpd.Tree
 import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.core.Flags
 import dotty.tools.dotc.core.Flags.*
@@ -24,7 +24,7 @@ import dotty.tools.pc.utils.MtagsEnrichments.*
 import org.eclipse.lsp4j as l
 
 import java.util as ju
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.meta.internal.metals.ReportContext
 import scala.meta.pc.OffsetParams
 import scala.meta.pc.PresentationCompilerConfig

--- a/presentation-compiler/src/main/dotty/tools/pc/printer/ShortenedTypePrinter.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/printer/ShortenedTypePrinter.scala
@@ -11,8 +11,8 @@ import dotty.tools.dotc.core.Names.NameOrdering
 import dotty.tools.dotc.core.StdNames
 import dotty.tools.dotc.core.Symbols.NoSymbol
 import dotty.tools.dotc.core.Symbols.Symbol
-import dotty.tools.dotc.core.Types.Type
 import dotty.tools.dotc.core.Types.*
+import dotty.tools.dotc.core.Types.Type
 import dotty.tools.dotc.printing.RefinedPrinter
 import dotty.tools.dotc.printing.Texts.Text
 import dotty.tools.pc.AutoImports.AutoImportsGenerator

--- a/presentation-compiler/test/dotty/tools/pc/base/BasePCSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/base/BasePCSuite.scala
@@ -1,10 +1,10 @@
 package dotty.tools.pc.base
 
-import dotty.tools.pc.ScalaPresentationCompiler
 import dotty.tools.pc.*
+import dotty.tools.pc.ScalaPresentationCompiler
 import dotty.tools.pc.completions.CompletionSource
 import dotty.tools.pc.tests.buildinfo.BuildInfo
-import dotty.tools.pc.utils._
+import dotty.tools.pc.utils.*
 import org.eclipse.lsp4j.MarkupContent
 import org.eclipse.lsp4j.jsonrpc.messages.Either as JEither
 import org.junit.runner.RunWith

--- a/presentation-compiler/test/dotty/tools/pc/base/BasePcDefinitionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/base/BasePcDefinitionSuite.scala
@@ -5,8 +5,8 @@ import dotty.tools.dotc.util.SourcePosition
 import dotty.tools.dotc.util.Spans.Span
 import dotty.tools.pc.utils.MtagsEnrichments.toLsp
 import dotty.tools.pc.utils.TextEdits
-import org.eclipse.lsp4j.TextEdit
 import org.eclipse.lsp4j as l
+import org.eclipse.lsp4j.TextEdit
 
 import java.nio.file.Paths
 import scala.language.unsafeNulls

--- a/presentation-compiler/test/dotty/tools/pc/base/BaseSelectionRangeSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/base/BaseSelectionRangeSuite.scala
@@ -1,6 +1,6 @@
 package dotty.tools.pc.base
 
-import dotty.tools.pc.utils.TestExtensions._
+import dotty.tools.pc.utils.TestExtensions.*
 import org.eclipse.lsp4j as l
 
 import java.nio.file.Paths

--- a/presentation-compiler/test/dotty/tools/pc/base/BaseSyntheticDecorationsSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/base/BaseSyntheticDecorationsSuite.scala
@@ -5,7 +5,7 @@ import org.eclipse.lsp4j.TextEdit
 
 import java.net.URI
 import scala.language.unsafeNulls
-import scala.meta.internal.jdk.CollectionConverters._
+import scala.meta.internal.jdk.CollectionConverters.*
 import scala.meta.internal.metals.CompilerSyntheticDecorationsParams
 import scala.meta.internal.metals.CompilerVirtualFileParams
 

--- a/presentation-compiler/test/dotty/tools/pc/base/ReusableClassRunner.scala
+++ b/presentation-compiler/test/dotty/tools/pc/base/ReusableClassRunner.scala
@@ -4,7 +4,7 @@ import org.junit.runners.BlockJUnit4ClassRunner
 import org.junit.runners.model.FrameworkMethod
 import org.junit.runners.model.Statement
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.language.unsafeNulls
 
 class ReusableClassRunner(testClass: Class[BasePCSuite])

--- a/presentation-compiler/test/dotty/tools/pc/utils/MockSymbolSearch.scala
+++ b/presentation-compiler/test/dotty/tools/pc/utils/MockSymbolSearch.scala
@@ -3,8 +3,8 @@ package dotty.tools.pc.utils
 import org.eclipse.lsp4j.Location
 
 import java.net.URI
-import java.util.Optional
 import java.util as ju
+import java.util.Optional
 import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters.*
 import scala.language.unsafeNulls

--- a/presentation-compiler/test/dotty/tools/pc/utils/ScalaSymbolDocumentation.scala
+++ b/presentation-compiler/test/dotty/tools/pc/utils/ScalaSymbolDocumentation.scala
@@ -1,6 +1,6 @@
 package dotty.tools.pc.utils
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.meta.pc.SymbolDocumentation
 
 case class ScalaSymbolDocumentation(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -23,3 +23,5 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.2")
 addSbtPlugin("ch.epfl.scala" % "sbt-tasty-mima" % "1.0.0")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.11.1")
+resolvers += Resolver.sonatypeRepo("snapshots")
+dependencyOverrides += "ch.epfl.scala" % "scalafix-interfaces" % "0.11.1+82-6d329592-SNAPSHOT"

--- a/tasty/src/dotty/tools/tasty/TastyReader.scala
+++ b/tasty/src/dotty/tools/tasty/TastyReader.scala
@@ -3,7 +3,7 @@ package dotty.tools.tasty
 import java.nio.charset.StandardCharsets
 
 import collection.mutable
-import TastyBuffer._
+import TastyBuffer.*
 
 /** A byte array buffer that can be filled with bytes or natural numbers in TASTY format,
  *  and that supports reading and patching addresses represented as natural numbers.

--- a/tasty/test/dotty/tools/tasty/TastyVersionFormatTest.scala
+++ b/tasty/test/dotty/tools/tasty/TastyVersionFormatTest.scala
@@ -1,11 +1,11 @@
 package dotty.tools.tasty
 
-import org.junit.Assert._
+import org.junit.Assert.*
 import org.junit.Ignore
 import org.junit.Test
 
-import TastyFormat._
-import TastyBuffer._
+import TastyFormat.*
+import TastyBuffer.*
 
 class TastyVersionFormatTest {
 


### PR DESCRIPTION
Testing https://github.com/scalacenter/scalafix/pull/1896

See also https://github.com/bjaglin/dotty/pull/2 or https://github.com/bjaglin/dotty/compare/OrganizeImportsDialectTargetScala2..OrganizeImportsDialectTargetScala3